### PR TITLE
Externalized the y-offset of undo popup to a dimensions resource

### DIFF
--- a/EnhancedListView/src/main/java/de/timroes/android/listview/EnhancedListView.java
+++ b/EnhancedListView/src/main/java/de/timroes/android/listview/EnhancedListView.java
@@ -826,10 +826,11 @@ public class EnhancedListView extends ListView {
                         changeButtonLabel();
 
                         // Show undo popup
+                        float yLocationOffset = getResources().getDimension(R.dimen.elv_bottom_offset);
                         mUndoPopup.setWidth((int)Math.min(mScreenDensity * 400, getWidth() * 0.9f));
                         mUndoPopup.showAtLocation(EnhancedListView.this,
                                 Gravity.CENTER_HORIZONTAL | Gravity.BOTTOM,
-                                0, (int)(mScreenDensity * 15));
+                                0, (int) yLocationOffset);
 
                         // Queue the dismiss only if required
                         if(!mTouchBeforeAutoHide) {

--- a/EnhancedListView/src/main/res/values/dimens.xml
+++ b/EnhancedListView/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="elv_bottom_offset">10dp</dimen>
+</resources>


### PR DESCRIPTION
The plugin now reads the location of the undo popup's offset from bottom from a dimensions resource file. 
Users can override this by define the `elv_bottom_offset` dimension value in their projects. 

I use the `elv` prefix so users don't accidentally override the value (as is possible with other resources currently).

The offset is from the bottom of the screen. I didn't think changing the gravity to center for example, would be of any benefit and would also not be in-line with Android design. The use case for this is probably similar to mine in Issue #25 where the current popup overlaps some UI component. 
